### PR TITLE
Don't display search when Elasticsearch is offline

### DIFF
--- a/collectiegroesbeek/controller.py
+++ b/collectiegroesbeek/controller.py
@@ -117,3 +117,14 @@ def get_names_list(q):
     raw = resp.json()
     names_list = raw['aggregations']['op_naam']['buckets']
     return names_list
+
+
+def is_elasticsearch_reachable() -> bool:
+    """Return a boolean whether the Elasticsearch service is available on localhost."""
+    try:
+        resp = requests.get('http://localhost:9200')
+        resp.raise_for_status()
+    except requests.exceptions.ConnectionError:
+        return False
+    else:
+        return True

--- a/collectiegroesbeek/templates/index.html
+++ b/collectiegroesbeek/templates/index.html
@@ -1,24 +1,13 @@
 
 {% extends "layout.html" %}
+{% import 'macros.html' as macros %}
 
 {% block title %}Collectie Groesbeek{% endblock %}
 
 
 {% block content %}
 
-<div class="jumbotron text-center border-bottom">
-    <h1 class="display-4">Collectie Groesbeek</h1>
-    <p class="lead">Indexen uit het archief van mr. J.W. Groesbeek, oud-rijksarchivaris</p>
-
-    <form action="/zoek">
-        <div class="form-group">
-            <div class="col-lg-8 offset-lg-2">
-                <input type="text" class="form-control" name="q" placeholder="zoek op naam (Altena), plaats (Leiden), jaartal (1316), of letters (k of ke)" autofocus>
-            </div>
-        </div>
-        <button type="submit" class="btn">Zoek</button>
-    </form>
-</div>
+{{ macros.jumbotron_search(show_search) }}
 
 <div class="index-item border-bottom">
 <div class="row">

--- a/collectiegroesbeek/templates/macros.html
+++ b/collectiegroesbeek/templates/macros.html
@@ -1,0 +1,22 @@
+
+{% macro jumbotron_search(show_search) -%}
+
+<div class="jumbotron text-center border-bottom">
+    <h1 class="display-4">Collectie Groesbeek</h1>
+    <p class="lead">Indexen uit het archief van mr. J.W. Groesbeek, oud-rijksarchivaris</p>
+
+    {% if show_search == true %}
+    <form action="/zoek">
+        <div class="form-group">
+            <div class="col-lg-8 offset-lg-2">
+                <input type="text" class="form-control" name="q" placeholder="zoek op naam (Altena), plaats (Leiden), jaartal (1316), of letters (k of ke)" autofocus>
+            </div>
+        </div>
+        <button type="submit" class="btn">Zoek</button>
+    </form>
+    {% elif show_search == false %}
+    <p>De zoekfunctie is op dit moment niet online. Probeer het later nog eens of neem contact op met de beheerder.</p>
+    {% endif %}
+</div>
+
+{%- endmacro %}

--- a/collectiegroesbeek/templates/search.html
+++ b/collectiegroesbeek/templates/search.html
@@ -1,24 +1,12 @@
 
 {% extends "layout.html" %}
+{% import 'macros.html' as macros %}
 
 {% block title %}Collectie Groesbeek{% endblock %}
 
 
 {% block content %}
 
-<div class="jumbotron text-center">
-    <h1 class="display-4">Collectie Groesbeek</h1>
-    <p class="lead">Indexen uit het archief van mr. J.W. Groesbeek, oud-rijksarchivaris</p>
-
-    <form action="/zoek">
-        <div class="form-group">
-            <div class="col-lg-8 offset-lg-2">
-                <input type="text" class="form-control" name="q" placeholder="zoek op naam (Altena), plaats (Leiden), jaartal (1316), of letters (k of ke)" autofocus>
-            </div>
-        </div>
-        <button type="submit" class="btn">Zoek</button>
-    </form>
-</div>
-
+{{ macros.jumbotron_search(show_search) }}
 
 {% endblock %}

--- a/collectiegroesbeek/view.py
+++ b/collectiegroesbeek/view.py
@@ -7,17 +7,24 @@ from . import controller
 @app.route('/')
 def home():
     q = flask.request.args.get('q')
-    if not q:
-        return flask.render_template('index.html')
-    else:
-        return search()
+    return index() if not q else search()
+
+
+def index():
+    return flask.render_template(
+        'index.html',
+        show_search=controller.is_elasticsearch_reachable(),
+    )
 
 
 @app.route('/zoek')
 def search():
     q = flask.request.args.get('q')
     if not q:
-        return flask.render_template('search.html')
+        return flask.render_template(
+            'search.html',
+            show_search=controller.is_elasticsearch_reachable(),
+        )
     elif len(q) <= 2:
         return show_names_list(q)
     cards_per_page = 10
@@ -40,7 +47,7 @@ def search():
 def show_names_list(q):
     for letter in q.lower():
         if not letter.isalpha():
-            return flask.render_template('index.html')
+            return index()
     names_list = controller.get_names_list(q)
     hits_total = len(names_list)
     return flask.render_template('names.html', namen=names_list, hits_total=hits_total)


### PR DESCRIPTION
Implemented a very simple check if Elasticsearch is reachable. This is currently done on each page load, so that could be optimized later.

I also moved the jumbotron item to a macro so we can stay DRY.